### PR TITLE
v0.0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Example:
     - **Password**: Your Nexio password
         _(If you have questions or if you need a Nexio username and password, please contact integrations@nexiopay.com)_
     - **Merchant Id**: The merchant id of your Nexio account
+    - **Share Secret**: The share secret of merchant, it is used for signatrue verification
     - **CSS**: The URL where your CSS file is hosted (required for custom CSS).
     - **Custom Text File**: The URL where your custom text file is hosted.
     - **Fraud Check**: Enable fraud check through Kount.
@@ -46,6 +47,7 @@ Example:
     - **Hide CVC**: Hide CVC.
     - **Hide Billing**: Hide billing info.
     - **Auth Only**: Make the transaction auth only.
+    - **Signature Verify**: Enable or disable signature verification.
 9. Scroll to the bottom of the page and click ‘Save changes’.
 Example:
 ![Payment methods settings example](screenshots/paymentMethodSettings.png)
@@ -99,3 +101,4 @@ Example:
 * 0.0.9 - 2019-04-18
 * 0.0.10 - 2019-04-23
 * 0.0.11 - 2019-05-04
+* 0.0.12 - 2019-05-08

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Example:
 4. Fill in card information and submit the transaction:
     a. Once the ‘Pay for order’ page has loaded you will see a Nexio payment form.
     b. Enter in the required fields.
-    c. Click the ‘Pay via Nexio’ button to submit the transaction.
+    c. Click the ‘Pay Now’ button to submit the transaction.
     d. If the transaction succeeds, you will see an ‘order received’ page, otherwise, it will return to checkout page for retry.
     Example:
     ![Pay for order example](screenshots/payForOrder.png)
@@ -102,3 +102,4 @@ Example:
 * 0.0.10 - 2019-04-23
 * 0.0.11 - 2019-05-04
 * 0.0.12 - 2019-05-08
+* 0.0.13 - 2019-05-09

--- a/assets/css/cms_orderpay.css
+++ b/assets/css/cms_orderpay.css
@@ -1,4 +1,10 @@
 .cms_iframe {
     border:0;
     height: 750px;
+    width: 100%;
+}
+
+#cms_payment_form{
+    height: 900px; 
+    width: 400px;
 }

--- a/assets/css/cms_orderpay.css
+++ b/assets/css/cms_orderpay.css
@@ -1,4 +1,5 @@
 .cms_iframe {
+    position:relative;
     border:0;
     height: 750px;
     width: 100%;
@@ -8,3 +9,26 @@
     height: 900px; 
     width: 400px;
 }
+
+#loader {
+    position: relative;
+    top: -40px;
+    border: 1px solid #ccc;
+    border-top: 1px solid #000;
+    border-radius: 50%;
+    width: 70px;
+    height: 70px;
+    animation: spin 1s linear infinite;
+    display: none;
+ }
+ 
+ 
+ 
+ @keyframes spin {
+     from {
+         transform:rotate(0deg);
+     }
+     to {
+         transform:rotate(360deg);
+     }
+ }

--- a/class-cms-gateway-nexio.php
+++ b/class-cms-gateway-nexio.php
@@ -674,6 +674,7 @@ class CMS_Gateway_Nexio extends WC_Payment_Gateway_CC {
 				cms_payment_form.addEventListener("submit", function processPayment(event) {
 				event.preventDefault();
 				iframe1.contentWindow.postMessage("posted", "'.$onetimetoken.'");
+				document.getElementById("loader").style.display = "block";
 				return false;
 			});
 			window.addEventListener("message", function messageListener(event) {
@@ -682,7 +683,17 @@ class CMS_Gateway_Nexio extends WC_Payment_Gateway_CC {
 						window.document.getElementById("iframe1").style.display = "block";
 						window.document.getElementById("loader").style.display = "none";
 					}
+					if (event.data.event === "formValidations")
+					{
+						Object.keys(event.data.data).forEach(function(key){
+							if(event.data.data[key] == false)
+							{
+								window.document.getElementById("loader").style.display = "none";
+							}
+						})	
+					}
 					if (event.data.event === "processed") {
+						document.getElementById("loader").style.display = "none";
 						try{
 							if("'.$this->fraud.'" === "yes")
 							{
@@ -711,6 +722,7 @@ class CMS_Gateway_Nexio extends WC_Payment_Gateway_CC {
 						
 					}
 					if (event.data.event === "error"){
+						document.getElementById("loader").style.display = "none";
 						var msg = event.data.data.message;
 						
 						window.document.getElementById("p1").innerHTML = "";
@@ -724,10 +736,9 @@ class CMS_Gateway_Nexio extends WC_Payment_Gateway_CC {
 		wp_enqueue_style( 'cms_orderpay' );	
 
 		return $testwarning.'<p id="p1">Please enter your payment information in the form below.</p><form id="cms_payment_form" action="'.esc_url( $onetimetoken ).'" method="post">
-		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe>
+		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe><div id="loader"></div>
 		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay Now', 'cms-gateway-nexio').'" />
-		</form>
-		<div id="loader"></div>';
+		</form>';
 
 	}
 		

--- a/cms-gateway-nexio.php
+++ b/cms-gateway-nexio.php
@@ -4,7 +4,7 @@
  * Description: Take credit card payments on your store using Nexio.
  * Author: Complete Merchant Solutions
  * Author URI: https://www.cmsonline.com/
- * Version: 0.0.11
+ * Version: 0.0.12
  * Requires at least: 4.4
  * Tested up to: 5.0
  * WC requires at least: 3.0
@@ -90,6 +90,7 @@ function woocommerce_gateway_nexio_init() {
 			 */
 			private function __construct() {
 				add_action( 'admin_init', array( $this, 'install' ) );
+				//error_log("!!!!!gateway construct is called!!!!!");
 				$this->init();
 			}
 
@@ -100,7 +101,7 @@ function woocommerce_gateway_nexio_init() {
 			 * @version 4.0.0
 			 */
 			public function init() {
-				
+				//error_log("!!!!!gateway init is called!!!!!");
 				require_once dirname( __FILE__ ) . '/class-cms-gateway-nexio.php';
 
 				add_filter( 'woocommerce_payment_gateways', array($this,'add_gateways') );				

--- a/cms-gateway-nexio.php
+++ b/cms-gateway-nexio.php
@@ -4,7 +4,7 @@
  * Description: Take credit card payments on your store using Nexio.
  * Author: Complete Merchant Solutions
  * Author URI: https://www.cmsonline.com/
- * Version: 0.0.12
+ * Version: 0.0.13
  * Requires at least: 4.4
  * Tested up to: 5.0
  * WC requires at least: 3.0

--- a/nexio-settings.php
+++ b/nexio-settings.php
@@ -59,6 +59,14 @@ return apply_filters(
 			'default'     => '',
 			'desc_tip'    => true,
 		),
+		'shareSecret'                       => array(
+			'title'       => __( 'Shared Secret', 'cms-gateway-nexio' ),
+			'label'       => __( 'Shared Secret of merchant', 'cms-gateway-nexio' ),
+			'type'        => 'password',
+			'description' => __( 'Shared Secret of merchant', 'cms-gateway-nexio' ),
+			'default'     => '',
+			'desc_tip'    => true,
+		),
 		'css'                       	=> array(
 			'title'       => __( 'CSS', 'cms-gateway-nexio' ),
 			'label'       => __( 'CSS file location', 'cms-gateway-nexio' ),
@@ -109,6 +117,13 @@ return apply_filters(
 			'type'        => 'checkbox',
 			'description' => '',
 			'default'     => 'no',
+		),
+		'signatureverify'                       => array(
+			'title'       => __( 'Verify Signature', 'cms-gateway-nexio' ),
+			'label'       => __( 'Verify Signature', 'cms-gateway-nexio' ),
+			'type'        => 'checkbox',
+			'description' => '',
+			'default'     => 'yes',
 		),
 	)
 );

--- a/tests/test-class-cms-gateway-nexio.php
+++ b/tests/test-class-cms-gateway-nexio.php
@@ -416,9 +416,9 @@ class TestClassCMSGatewayNexio extends WC_Unit_Test_Case{
         $onetimetoken = $mockedObject->get_iframe_src('123456');
 
         $return = $mockedObject->generate_nexio_form($order_id);
-        $return2 = '<p id="p1">Thank you for your order, please input your payment information in blow form and click the button to submit transaction.</p><form id="cms_payment_form" height="900px" width="400px" action="'.esc_url( $onetimetoken ).'" method="post">
+        $return2 = '<p id="p1">Please enter your payment information in the form below.</p><form id="cms_payment_form" action="'.esc_url( $onetimetoken ).'" method="post">
 		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe>
-		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay via Nexio', 'cms-gateway-nexio').'" />
+		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay Now', 'cms-gateway-nexio').'" />
 		</form>
 		<div id="loader"></div>';
         $return = trim(preg_replace('/\s\s+/', ' ', $return));
@@ -472,9 +472,9 @@ class TestClassCMSGatewayNexio extends WC_Unit_Test_Case{
         
 
         $return = $mockedObject->generate_nexio_form($order_id);
-        $return2 = '<p id="p1">Thank you for your order, please input your payment information in blow form and click the button to submit transaction.</p><form id="cms_payment_form" height="900px" width="400px" action="'.esc_url( $onetimetoken ).'" method="post">
+        $return2 = '<p id="p1">Please enter your payment information in the form below.</p><form id="cms_payment_form" action="'.esc_url( $onetimetoken ).'" method="post">
 		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe>
-		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay via Nexio', 'cms-gateway-nexio').'" />
+		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay Now', 'cms-gateway-nexio').'" />
 		</form>
 		<div id="loader"></div>';
         $return = trim(preg_replace('/\s\s+/', ' ', $return));

--- a/tests/test-class-cms-gateway-nexio.php
+++ b/tests/test-class-cms-gateway-nexio.php
@@ -417,10 +417,9 @@ class TestClassCMSGatewayNexio extends WC_Unit_Test_Case{
 
         $return = $mockedObject->generate_nexio_form($order_id);
         $return2 = '<p id="p1">Please enter your payment information in the form below.</p><form id="cms_payment_form" action="'.esc_url( $onetimetoken ).'" method="post">
-		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe>
+		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe><div id="loader"></div>
 		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay Now', 'cms-gateway-nexio').'" />
-		</form>
-		<div id="loader"></div>';
+		</form>';
         $return = trim(preg_replace('/\s\s+/', ' ', $return));
         $return2 = trim(preg_replace('/\s\s+/', ' ', $return2));
 
@@ -473,10 +472,9 @@ class TestClassCMSGatewayNexio extends WC_Unit_Test_Case{
 
         $return = $mockedObject->generate_nexio_form($order_id);
         $return2 = '<p id="p1">Please enter your payment information in the form below.</p><form id="cms_payment_form" action="'.esc_url( $onetimetoken ).'" method="post">
-		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe>
+		<iframe type="iframe" class="cms_iframe" id="iframe1" src="'.$onetimetoken.'"></iframe><div id="loader"></div>
 		<input type="submit" class="button" id="submit_cms_payment_form" value="'.__('Pay Now', 'cms-gateway-nexio').'" />
-		</form>
-		<div id="loader"></div>';
+		</form>';
         $return = trim(preg_replace('/\s\s+/', ' ', $return));
         $return2 = trim(preg_replace('/\s\s+/', ' ', $return2));
 


### PR DESCRIPTION
1. Add 'Share Secret' and 'Signature Verify' options in plugin settings
2. Change way to udpate share secret. When plugin is inited, only get secret if it's empty or 'error'. If it's still 'error' or empty after get_secret() called, do update_secret(). Save result into 'Share Secret' option.
3. Fixed one bug of showing get token error message to user when user authentication failed.
4. Modified readme.md accordingly. But instruction document and screenshots are not update yet.
5. Clean up the process where Fraud is turned on in WooCommerce, but off in Nexio.
6. Add phone, email, shipToAddressOne, shipToAddressTwo, shipToCity, shipToState, shipToPostalCode,shipToCountry into customer filed when request one time use token.
7. Add saveCardToken into processingOptions filed when request one time use token, the value is set to false.
8. Modify cms_orderpay.css to make iFrame more wide, also move cms_payment_form style into the css file.
9. Change "Pay via Nexio" to "Pay Now".
10. Change "Thank you for your order, please input your payment information in blow form and click the button to submit transaction." to "Please enter your payment information in the form below."
11. Add spinner when click 'Pay Now' button. Adjust Javascript to hide the spinner when iframe form validation has problem.